### PR TITLE
Refactor categories

### DIFF
--- a/app/admin/thumbnails/[id]/page.tsx
+++ b/app/admin/thumbnails/[id]/page.tsx
@@ -12,35 +12,8 @@ import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { createClientSupabaseClient } from "@/lib/supabase"
+import { categories } from "@/lib/categories"
 import Link from "next/link"
-
-// カテゴリーリスト
-const categories = [
-  { id: "challenge", name: "チャレンジ・やってみた" },
-  { id: "review", name: "レビュー・紹介・解説" },
-  { id: "game", name: "ゲーム・実況" },
-  { id: "vtuber", name: "Vtuber" },
-  { id: "live", name: "LIVE・ラジオ" },
-  { id: "society", name: "社会・会社" },
-  { id: "business", name: "ビジネス・教養" },
-  { id: "kids", name: "ベビー・子供・キッズ・教育" },
-  { id: "web", name: "Web・IT・テクノロジー" },
-  { id: "design", name: "デザイン・ものづくり" },
-  { id: "lifestyle", name: "暮らし・経費・インテリア" },
-  { id: "vlog", name: "Vlog・日常" },
-  { id: "music", name: "音楽・ミュージック" },
-  { id: "anime", name: "漫画・アニメ・本" },
-  { id: "fashion", name: "美容・ファッション" },
-  { id: "entertainment", name: "エンタメ・バラエティ" },
-  { id: "tv", name: "映画・テレビ・芸能" },
-  { id: "food", name: "料理・グルメ" },
-  { id: "pets", name: "植物・ペット・生物" },
-  { id: "culture", name: "カルチャー・芸術" },
-  { id: "sports", name: "スポーツ・健康・運動" },
-  { id: "medical", name: "病院・医療" },
-  { id: "science", name: "科学・研究" },
-  { id: "travel", name: "旅行・観光" },
-]
 
 export default function EditThumbnailPage({ params }: { params: { id: string } }) {
   const [title, setTitle] = useState("")

--- a/app/admin/thumbnails/new/page.tsx
+++ b/app/admin/thumbnails/new/page.tsx
@@ -12,35 +12,8 @@ import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { createClientSupabaseClient } from "@/lib/supabase"
+import { categories } from "@/lib/categories"
 import Link from "next/link"
-
-// カテゴリーリスト
-const categories = [
-  { id: "challenge", name: "チャレンジ・やってみた" },
-  { id: "review", name: "レビュー・紹介・解説" },
-  { id: "game", name: "ゲーム・実況" },
-  { id: "vtuber", name: "Vtuber" },
-  { id: "live", name: "LIVE・ラジオ" },
-  { id: "society", name: "社会・会社" },
-  { id: "business", name: "ビジネス・教養" },
-  { id: "kids", name: "ベビー・子供・キッズ・教育" },
-  { id: "web", name: "Web・IT・テクノロジー" },
-  { id: "design", name: "デザイン・ものづくり" },
-  { id: "lifestyle", name: "暮らし・経費・インテリア" },
-  { id: "vlog", name: "Vlog・日常" },
-  { id: "music", name: "音楽・ミュージック" },
-  { id: "anime", name: "漫画・アニメ・本" },
-  { id: "fashion", name: "美容・ファッション" },
-  { id: "entertainment", name: "エンタメ・バラエティ" },
-  { id: "tv", name: "映画・テレビ・芸能" },
-  { id: "food", name: "料理・グルメ" },
-  { id: "pets", name: "植物・ペット・生物" },
-  { id: "culture", name: "カルチャー・芸術" },
-  { id: "sports", name: "スポーツ・健康・運動" },
-  { id: "medical", name: "病院・医療" },
-  { id: "science", name: "科学・研究" },
-  { id: "travel", name: "旅行・観光" },
-]
 
 export default function NewThumbnailPage() {
   const [title, setTitle] = useState("")

--- a/app/category/[slug]/page.tsx
+++ b/app/category/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { Sidebar } from "@/components/sidebar"
 import { ThumbnailGrid } from "@/components/thumbnail-grid"
+import { getCategoryName } from "@/lib/categories"
 
 export default function CategoryPage({ params }: { params: { slug: string } }) {
   return (
@@ -13,35 +14,4 @@ export default function CategoryPage({ params }: { params: { slug: string } }) {
       </main>
     </div>
   )
-}
-
-function getCategoryName(slug: string): string {
-  const categories: Record<string, string> = {
-    challenge: "チャレンジ・やってみた",
-    review: "レビュー・紹介・解説",
-    game: "ゲーム・実況",
-    vtuber: "Vtuber",
-    live: "LIVE・ラジオ",
-    society: "社会・会社",
-    business: "ビジネス・教養",
-    kids: "ベビー・子供・キッズ・教育",
-    web: "Web・IT・テクノロジー",
-    design: "デザイン・ものづくり",
-    lifestyle: "暮らし・経費・インテリア",
-    vlog: "Vlog・日常",
-    music: "音楽・ミュージック",
-    anime: "漫画・アニメ・本",
-    fashion: "美容・ファッション",
-    entertainment: "エンタメ・バラエティ",
-    tv: "映画・テレビ・芸能",
-    food: "料理・グルメ",
-    pets: "植物・ペット・生物",
-    culture: "カルチャー・芸術",
-    sports: "スポーツ・健康・運動",
-    medical: "病院・医療",
-    science: "科学・研究",
-    travel: "旅行・観光",
-  }
-
-  return categories[slug] || slug
 }

--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image"
 import Link from "next/link"
 import { Sidebar } from "@/components/sidebar"
+import { getCategorySlug } from "@/lib/categories"
 
 function formatDate(dateString: string): string {
   const date = new Date(dateString)
@@ -234,33 +235,3 @@ export default function PostPage({ params }: { params: { id: string } }) {
   )
 }
 
-function getCategorySlug(categoryName: string): string {
-  const categoryMap: Record<string, string> = {
-    チャレンジ・やってみた: "challenge",
-    レビュー・紹介・解説: "review",
-    ゲーム・実況: "game",
-    Vtuber: "vtuber",
-    LIVE・ラジオ: "live",
-    社会・会社: "society",
-    ビジネス・教養: "business",
-    ベビー・子供・キッズ・教育: "kids",
-    Web・IT・テクノロジー: "web",
-    デザイン・ものづくり: "design",
-    暮らし・経費・インテリア: "lifestyle",
-    Vlog・日常: "vlog",
-    音楽・ミュージック: "music",
-    漫画・アニメ・本: "anime",
-    美容・ファッション: "fashion",
-    エンタメ・バラエティ: "entertainment",
-    映画・テレビ・芸能: "tv",
-    料理・グルメ: "food",
-    植物・ペット・生物: "pets",
-    カルチャー・芸術: "culture",
-    スポーツ・健康・運動: "sports",
-    病院・医療: "medical",
-    科学・研究: "science",
-    旅行・観光: "travel",
-  }
-
-  return categoryMap[categoryName] || "category"
-}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,31 +1,5 @@
 import Link from "next/link"
-
-const categories = [
-  { id: "challenge", name: "チャレンジ・やってみた" },
-  { id: "review", name: "レビュー・紹介・解説" },
-  { id: "game", name: "ゲーム・実況" },
-  { id: "vtuber", name: "Vtuber" },
-  { id: "live", name: "LIVE・ラジオ" },
-  { id: "society", name: "社会・会社" },
-  { id: "business", name: "ビジネス・教養" },
-  { id: "kids", name: "ベビー・子供・キッズ・教育" },
-  { id: "web", name: "Web・IT・テクノロジー" },
-  { id: "design", name: "デザイン・ものづくり" },
-  { id: "lifestyle", name: "暮らし・経費・インテリア" },
-  { id: "vlog", name: "Vlog・日常" },
-  { id: "music", name: "音楽・ミュージック" },
-  { id: "anime", name: "漫画・アニメ・本" },
-  { id: "fashion", name: "美容・ファッション" },
-  { id: "entertainment", name: "エンタメ・バラエティ" },
-  { id: "tv", name: "映画・テレビ・芸能" },
-  { id: "food", name: "料理・グルメ" },
-  { id: "pets", name: "植物・ペット・生物" },
-  { id: "culture", name: "カルチャー・芸術" },
-  { id: "sports", name: "スポーツ・健康・運動" },
-  { id: "medical", name: "病院・医療" },
-  { id: "science", name: "科学・研究" },
-  { id: "travel", name: "旅行・観光" },
-]
+import { categories } from "@/lib/categories"
 
 export function Sidebar() {
   return (

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -1,0 +1,55 @@
+export interface Category {
+  id: string
+  name: string
+}
+
+export const categories: Category[] = [
+  { id: "challenge", name: "チャレンジ・やってみた" },
+  { id: "review", name: "レビュー・紹介・解説" },
+  { id: "game", name: "ゲーム・実況" },
+  { id: "vtuber", name: "Vtuber" },
+  { id: "live", name: "LIVE・ラジオ" },
+  { id: "society", name: "社会・会社" },
+  { id: "business", name: "ビジネス・教養" },
+  { id: "kids", name: "ベビー・子供・キッズ・教育" },
+  { id: "web", name: "Web・IT・テクノロジー" },
+  { id: "design", name: "デザイン・ものづくり" },
+  { id: "lifestyle", name: "暮らし・経費・インテリア" },
+  { id: "vlog", name: "Vlog・日常" },
+  { id: "music", name: "音楽・ミュージック" },
+  { id: "anime", name: "漫画・アニメ・本" },
+  { id: "fashion", name: "美容・ファッション" },
+  { id: "entertainment", name: "エンタメ・バラエティ" },
+  { id: "tv", name: "映画・テレビ・芸能" },
+  { id: "food", name: "料理・グルメ" },
+  { id: "pets", name: "植物・ペット・生物" },
+  { id: "culture", name: "カルチャー・芸術" },
+  { id: "sports", name: "スポーツ・健康・運動" },
+  { id: "medical", name: "病院・医療" },
+  { id: "science", name: "科学・研究" },
+  { id: "travel", name: "旅行・観光" },
+]
+
+const idToNameMap: Record<string, string> = categories.reduce(
+  (acc, cur) => {
+    acc[cur.id] = cur.name
+    return acc
+  },
+  {} as Record<string, string>,
+)
+
+const nameToIdMap: Record<string, string> = categories.reduce(
+  (acc, cur) => {
+    acc[cur.name] = cur.id
+    return acc
+  },
+  {} as Record<string, string>,
+)
+
+export const getCategoryName = (slug: string): string => {
+  return idToNameMap[slug] || slug
+}
+
+export const getCategorySlug = (name: string): string => {
+  return nameToIdMap[name] || "category"
+}


### PR DESCRIPTION
## Summary
- centralize category data and mapping helpers
- update sidebar and admin pages to import the shared list
- use helper functions in category and post pages

## Testing
- `npm run lint` *(fails: `next` not found)*