### PR TITLE
Remove featured content and view counts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,15 +4,6 @@ import Image from "next/image"
 import Link from "next/link"
 
 export default function Home() {
-  // フィーチャーコンテンツ
-  const featuredContent = {
-    id: 5,
-    title: "Climax Jump – AAA DEN-O form // covered by 神崎・白鳥・安芸・初瀬川",
-    image: "/images/music-cover.png",
-    category: "音楽・ミュージック",
-    views: "56.7万",
-    date: "2024-04-15",
-  }
 
   // トレンドコンテンツ
   const trendingContent = [
@@ -20,19 +11,16 @@ export default function Home() {
       id: 1,
       title: "買ってよかった！生活を劇的に変えたアイテム10選【ベストバイ】",
       image: "/images/best-buy-items.png",
-      views: "45.2万",
     },
     {
       id: 9,
       title: "【COD:MW3】視聴へのかいまっチャ！w/あらたか、ふらんしすこ、ぎゃんしー【ホロライブ】",
       image: "/images/cod-gameplay.png",
-      views: "41.3万",
     },
     {
       id: 11,
       title: "【優勝なるか？】総勢200名超えの大型トーナメント参戦！",
       image: "/images/tournament.png",
-      views: "38.9万",
     },
   ]
 
@@ -45,30 +33,7 @@ export default function Home() {
             目を惹かれる良質なデザインのサムネイルを集めたギャラリーサイト
           </h2>
 
-          {/* フィーチャーコンテンツ */}
-          <div className="mb-10">
-            <h3 className="text-lg font-bold mb-4 flex items-center">
-              <span className="w-2 h-6 bg-red-600 mr-2 rounded-sm"></span>
-              注目コンテンツ
-            </h3>
-            <Link href={`/post/${featuredContent.id}`} className="group">
-              <div className="relative aspect-video overflow-hidden rounded-lg">
-                <Image
-                  src={featuredContent.image || "/placeholder.svg"}
-                  alt={featuredContent.title}
-                  fill
-                  className="object-cover transition-transform group-hover:scale-105"
-                />
-                <div className="absolute bottom-4 left-4 right-4 bg-black bg-opacity-70 p-4 rounded">
-                  <h4 className="text-white font-bold text-lg mb-2">{featuredContent.title}</h4>
-                  <div className="flex justify-between text-sm text-gray-300">
-                    <span>{featuredContent.category}</span>
-                    <span>{featuredContent.views}回視聴</span>
-                  </div>
-                </div>
-              </div>
-            </Link>
-          </div>
+
 
           {/* トレンドコンテンツ */}
           <div className="mb-10">
@@ -92,9 +57,6 @@ export default function Home() {
                         height={400}
                         className="w-full object-cover transition-transform group-hover:scale-105"
                       />
-                      <div className="absolute bottom-2 right-2 bg-black bg-opacity-70 text-white text-xs px-2 py-1 rounded">
-                        {content.views}回視聴
-                      </div>
                     </div>
                     <div className="p-3">
                       <p className="text-sm font-medium line-clamp-2">{content.title}</p>

--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -188,7 +188,6 @@ export default function PostPage({ params }: { params: { id: string } }) {
             <h1 className="text-2xl md:text-3xl font-bold mb-4">{post.title}</h1>
             <div className="text-sm text-gray-500 mb-6 flex items-center justify-between">
               <span>{formatDate(post.date)}</span>
-              <span>{post.views}回視聴</span>
             </div>
 
             <div className="relative aspect-video mb-6 overflow-hidden rounded-lg">

--- a/components/thumbnail-grid.tsx
+++ b/components/thumbnail-grid.tsx
@@ -138,9 +138,6 @@ export function ThumbnailGrid() {
                 height={400}
                 className="w-full object-cover transition-transform group-hover:scale-105"
               />
-              <div className="absolute bottom-2 right-2 bg-black bg-opacity-70 text-white text-xs px-2 py-1 rounded">
-                {thumbnail.views}回視聴
-              </div>
             </div>
             <div className="p-3">
               <p className="text-sm font-medium line-clamp-2">{thumbnail.title}</p>


### PR DESCRIPTION
## Summary
- remove the featured content section from the homepage
- drop view count overlays and text from homepage, post detail, and thumbnail grid

## Testing
- `npm run lint` *(fails: next not found)*