### PR TITLE
Remove sample data, adjust thumbnail aspect ratio, auto-fill views

### DIFF
--- a/app/admin/thumbnails/[id]/delete/page.tsx
+++ b/app/admin/thumbnails/[id]/delete/page.tsx
@@ -107,7 +107,7 @@ export default function DeleteThumbnailPage({ params }: { params: { id: string }
           {thumbnail && (
             <div className="space-y-4">
               <div className="flex flex-col md:flex-row gap-6">
-                <div className="w-full md:w-1/3 relative h-40">
+                <div className="w-full md:w-1/3 relative aspect-video">
                   <Image
                     src={thumbnail.image_url || "/placeholder.svg"}
                     alt={thumbnail.title}

--- a/app/admin/thumbnails/new/page.tsx
+++ b/app/admin/thumbnails/new/page.tsx
@@ -21,7 +21,11 @@ async function fetchYoutubeInfo(url: string) {
   if (!res.ok) {
     throw new Error("YouTube情報の取得に失敗しました")
   }
-  return (await res.json()) as { title: string; imageUrl: string }
+  return (await res.json()) as {
+    title: string
+    imageUrl: string
+    viewCount: string
+  }
 }
 
 export default function NewThumbnailPage() {
@@ -45,6 +49,7 @@ export default function NewThumbnailPage() {
       const data = await fetchYoutubeInfo(youtubeUrl)
       setTitle(data.title)
       setImageUrl(data.imageUrl)
+      setViews(data.viewCount)
     } catch (err: any) {
       setError(err.message)
     } finally {

--- a/app/admin/thumbnails/page.tsx
+++ b/app/admin/thumbnails/page.tsx
@@ -42,7 +42,7 @@ export default async function ThumbnailsPage() {
                   key={thumbnail.id}
                   className="border rounded-lg overflow-hidden bg-white shadow-sm hover:shadow-md transition-shadow"
                 >
-                  <div className="relative h-40">
+                  <div className="relative aspect-video">
                     <Image
                       src={thumbnail.image_url || "/placeholder.svg"}
                       alt={thumbnail.title}

--- a/app/api/youtube/route.ts
+++ b/app/api/youtube/route.ts
@@ -15,7 +15,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "API key not configured" }, { status: 500 });
   }
   const res = await fetch(
-    `https://www.googleapis.com/youtube/v3/videos?part=snippet&id=${videoId}&key=${apiKey}`,
+    `https://www.googleapis.com/youtube/v3/videos?part=snippet,statistics&id=${videoId}&key=${apiKey}`,
   );
   if (!res.ok) {
     return NextResponse.json({ error: "Failed to fetch video info" }, { status: 500 });
@@ -24,11 +24,17 @@ export async function GET(req: NextRequest) {
   if (!json.items || json.items.length === 0) {
     return NextResponse.json({ error: "Video not found" }, { status: 404 });
   }
-  const snippet = json.items[0].snippet;
+  const item = json.items[0];
+  const snippet = item.snippet;
+  const viewCount = item.statistics?.viewCount || "0";
   const thumbnail =
     snippet.thumbnails?.high?.url ||
     snippet.thumbnails?.standard?.url ||
     snippet.thumbnails?.default?.url ||
     "";
-  return NextResponse.json({ title: snippet.title, imageUrl: thumbnail });
+  return NextResponse.json({
+    title: snippet.title,
+    imageUrl: thumbnail,
+    viewCount,
+  });
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,28 +1,9 @@
 import { Sidebar } from "@/components/sidebar"
 import { ThumbnailGrid } from "@/components/thumbnail-grid"
-import Image from "next/image"
 import Link from "next/link"
 
 export default function Home() {
 
-  // トレンドコンテンツ
-  const trendingContent = [
-    {
-      id: 1,
-      title: "買ってよかった！生活を劇的に変えたアイテム10選【ベストバイ】",
-      image: "/images/best-buy-items.png",
-    },
-    {
-      id: 9,
-      title: "【COD:MW3】視聴へのかいまっチャ！w/あらたか、ふらんしすこ、ぎゃんしー【ホロライブ】",
-      image: "/images/cod-gameplay.png",
-    },
-    {
-      id: 11,
-      title: "【優勝なるか？】総勢200名超えの大型トーナメント参戦！",
-      image: "/images/tournament.png",
-    },
-  ]
 
   return (
     <div className="flex flex-col md:flex-row min-h-screen">
@@ -35,37 +16,7 @@ export default function Home() {
 
 
 
-          {/* トレンドコンテンツ */}
-          <div className="mb-10">
-            <h3 className="text-lg font-bold mb-4 flex items-center">
-              <span className="w-2 h-6 bg-red-600 mr-2 rounded-sm"></span>
-              トレンド
-            </h3>
-            <div className="columns-1 sm:columns-2 lg:columns-3 gap-4">
-              {trendingContent.map((content) => (
-                <Link
-                  key={content.id}
-                  href={`/post/${content.id}`}
-                  className="group mb-4 break-inside-avoid"
-                >
-                  <div className="overflow-hidden rounded-lg border border-gray-200 transition-all group-hover:shadow-md">
-                    <div className="relative">
-                      <Image
-                        src={content.image || "/placeholder.svg"}
-                        alt={content.title}
-                        width={600}
-                        height={400}
-                        className="w-full object-cover transition-transform group-hover:scale-105"
-                      />
-                    </div>
-                    <div className="p-3">
-                      <p className="text-sm font-medium line-clamp-2">{content.title}</p>
-                    </div>
-                  </div>
-                </Link>
-              ))}
-            </div>
-          </div>
+
 
           {/* 最新コンテンツ */}
           <div>

--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -77,8 +77,8 @@ export default async function PostPage({ params }: { params: { id: string } }) {
                         <Image
                           src={related.image_url || "/placeholder.svg"}
                           alt={related.title}
-                          width={600}
-                          height={400}
+                          width={640}
+                          height={360}
                           className="w-full object-cover transition-transform group-hover:scale-105"
                         />
                       </div>

--- a/components/thumbnail-grid.tsx
+++ b/components/thumbnail-grid.tsx
@@ -56,8 +56,8 @@ export async function ThumbnailGrid({ category }: ThumbnailGridProps) {
               <Image
                 src={thumbnail.image_url || "/placeholder.svg"}
                 alt={thumbnail.title}
-                width={600}
-                height={400}
+                width={640}
+                height={360}
                 className="w-full object-cover transition-transform group-hover:scale-105"
               />
             </div>


### PR DESCRIPTION
## Summary
- remove hard-coded trending content from home page
- fetch YouTube view count in `/api/youtube`
- auto-fill views when retrieving YouTube info in the admin panel
- update thumbnail images to 16:9 aspect ratio across the site

## Testing
- `pnpm lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*